### PR TITLE
Set `cwd` to the directory of the active file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.6.0 - Search for config file in current directory, then move up
+* [#10](https://github.com/TimKam/atomic-vale/issues/10): Removes vale configuration file parameter. Instead, atomic vale supports vale's default behavior: vale starts looking for the config in the same directory as the file vale is currently linting. If not found, vale moves up the directory tree until it finds a configuration file. vale v0.4.1 looks maximally six levels up, before it falls back to the default configuration.
 ## 1.5.0 - Fall back to default vale config
 * [#8](https://github.com/TimKam/atomic-vale/issues/8): Fix: throws exceptions if file starts with `--` (interprets text input as flag).
 ## 1.4.0 - Fall back to default vale config

--- a/README.md
+++ b/README.md
@@ -2,21 +2,17 @@
 Atomic vale is a [vale](https://github.com/ValeLint/vale) plugin for Atom.
 
 ## Installation
-1. [Install vale](https://github.com/ValeLint/vale#installation) for your
-command line.
+1. [Install vale](https://github.com/ValeLint/vale#installation) for your command line.
  **Note:** Atomic vale requires vale version **0.4.0** or higher.
 
-2. Then, install `atomic-vale` via the
-[Atom Settings View](http://flight-manual.atom.io/using-atom/sections/atom-packages/).
+2. Then, install `atomic-vale` via the [Atom Settings View](http://flight-manual.atom.io/using-atom/sections/atom-packages/).
 
 ## Configuration
 You manage your vale configuration in a
 [`.vale` or `_vale` file](https://github.com/ValeLint/vale#vale-your-style-our-editor).
+vale starts looking for this file in the same directory as the file vale is currently linting. If not found, vale moves up the directory tree until it finds a configuration file. vale v0.4.1 looks maximally six levels up, before it falls back to the default configuration.
 
-In the atomic vale configuration settings, you can specify the following
-parameters:
+In the atomic vale configuration settings, you can specify the following parameters:
 * The paths to your vale installation
-* The path to your vale configuration file
-* Whether the linter runs *on the fly* after each edit or merely after saving
-  the file
+* Whether the linter runs *on the fly* after each edit or merely after saving the file
 * A List of scopes for languages vale will lint

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -10,11 +10,6 @@ module.exports =
       title: 'Path to your vale installation'
       default: 'vale'
 
-    configPath:
-      type: 'string'
-      title: 'Path to your vale configuation file'
-      default: atom.project.getPaths()[0]
-
     lintOnFly:
       type: 'boolean'
       title: 'Run linter after each edit (not only after saving)'
@@ -46,10 +41,6 @@ module.exports =
     @subscriptions.add atom.config.observe 'atomic-vale.valePath',
         (valePath) =>
           @valePath = valePath
-
-    @subscriptions.add atom.config.observe 'atomic-vale.configPath',
-      (configPath) =>
-        @configPath = configPath
 
     @subscriptions.add atom.config.observe 'atomic-vale.lintOnFly',
       (lintOnFly) =>
@@ -118,7 +109,7 @@ module.exports =
         return new Promise (resolve, reject) =>
           getConfigProcess=process.spawn @valePath,
             ['dump-config'],
-            cwd: @configPath
+            cwd: fileDirectory
 
           getConfigProcess.stdout.on 'data', (data) => runLinter(data.toString(), resolve)
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -76,6 +76,7 @@ module.exports =
         filePath = textEditor.getPath()
         inputText = textEditor.getText()
         fileExtension = path.extname(filePath)
+        fileDirectory = path.dirname(filePath)
         output = "{}"
         config = "{}"
 
@@ -89,7 +90,7 @@ module.exports =
 
           lintProcess = process.spawn @valePath,
             ["--ext=#{fileExtension}", '--output=JSON', "'#{inputText}'"],
-            cwd: @configPath
+            cwd: fileDirectory
 
           lintProcess.stdout.on 'data', (data) =>
             output = data.toString()


### PR DESCRIPTION
Vale has the ability to support multiple configuration files in a single project. For example,

```none
docs/
├── blog/
│   ├── .vale
│   ├── B.md
├── .vale
├── A.md
```

Here, `A.md` and `B.md` are associated with different `.vale` files. By setting `cwd` to the parent directory of the active file, Vale should just do the "right thing." If a configuration file can't be found, Vale should also automatically fall back to its default settings. The algorithm is essentially the same as `JSHint`:

> In case of .jshintrc, JSHint will start looking for this file in the same directory as the file that's being linted. If not found, it will move one level up the directory tree all the way up to the filesystem root.

Except, for performance reasons, Vale only looks 6 levels up (although this may be increased) before falling back to the defaults.

This should also mean that user's don't need to specify the location of their configuration file, which is nice for people who use Atom to work on multiple projects.