### PR TITLE
Add rule reference to feedback message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.9.0 Add rule reference to feedback message
+* [#19](https://github.com/TimKam/atomic-vale/pull/19/): Improvement: adds the name of the rule that provides a feedback message to the linter output.
+* Support [Standard Linter v2](https://steelbrain.me/linter/examples/standard-linter-v2.html).
 ## 1.8.0 - Fix linter level for suggestions
 * [#16](https://github.com/TimKam/atomic-vale/pull/16): Fix: atomic-vale does not provide the necessary mapping from value's *suggestion* level to the Atom linter's *info* level.
 ## 1.7.0 - Fix exceptions when exceeding file length threshold

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -60,7 +60,7 @@ module.exports =
 
       scope: 'file'
 
-      lintOnFly: @lintOnFly
+      lintsOnChange: @lintOnFly
 
       lint: (textEditor) =>
         filePath = textEditor.getPath()
@@ -100,17 +100,18 @@ module.exports =
                 atomMessageLine = message.Line - 1
                 atomMessageRow = message.Span[0] - 1
                 isDuplicate = messages.some (existingMessage) =>
-                    existingMessage.range[0][0] == atomMessageLine and
-                    existingMessage.range[0][1] == atomMessageRow
+                    existingMessage.location.position[0][0] == atomMessageLine and
+                    existingMessage.location.position[0][1] == atomMessageRow
                 if not isDuplicate
                   messages.push
-                    type: if message.Severity == 'suggestion' then 'info' else message.Severity
-                    text: '#{message.Message} <#{message.Check}>'
-                    filePath: filePath
-                    range: [
-                      [atomMessageLine, atomMessageRow]
-                      [atomMessageLine, message.Span[1]]
-                    ]
+                    severity: if message.Severity == 'suggestion' then 'info' else message.Severity
+                    excerpt: "#{message.Message} (#{message.Check})"
+                    location:
+                      file: filePath
+                      position: [
+                        [atomMessageLine, atomMessageRow]
+                        [atomMessageLine, message.Span[1]]
+                      ]
 
               resolve messages
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -105,7 +105,7 @@ module.exports =
                 if not isDuplicate
                   messages.push
                     type: if message.Severity == 'suggestion' then 'info' else message.Severity
-                    text: message.Message
+                    text: '#{message.Message} <#{message.Check}>'
                     filePath: filePath
                     range: [
                       [atomMessageLine, atomMessageRow]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "atomic-vale",
+  "version": "1.8.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   }


### PR DESCRIPTION
I am using a lot of different rules and it's hard to keep track of them all. I therefore find it convenient to have the rule name in the feedback message. I'm guessing the same might be true for other users.